### PR TITLE
feat(1.x): deploy 配置支持通过环境变量设置

### DIFF
--- a/build-config.md
+++ b/build-config.md
@@ -291,13 +291,25 @@ const apiUrl = "http://foobar.com/api" + 'test'
 
     ```json
     {
-      "AccessKey": "xxx",
-      "SecretKey": "yyy",
+      "accessKey": "xxx",
+      "secretKey": "yyy",
       "bucket": "zzz"
     }
     ```    
 
-    表示使用 `xxx`、`yyy` 分别作为 AccessKey 与 SecretKey，上传到名为 `zzz` 的 bucket。
+    表示使用 `xxx`、`yyy` 分别作为 accessKey 与 secretKey，上传到名为 `zzz` 的 bucket。
+
+    也可以通过环境变量的形式来配置，例如：
+
+    ```json
+    {
+       "accessKey": "{{process.env.BUILD_DEPLOY_ACCESS_KEY}}",
+       "secretKey": "{{process.env.BUILD_DEPLOY_SECRET_KEY}}",
+       "bucket": "zzz"
+    }
+    ```    
+
+    表示使用环境变量 `BUILD_DEPLOY_ACCESS_KEY`、`BUILD_DEPLOY_SECRET_KEY` 的值分别作为 accessKey 与 secretKey，上传到名为 `zzz` 的 bucket。
 
 ## **`test`**
 

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -6,6 +6,7 @@
 const path = require('path')
 const walk = require('walk')
 const qiniu = require('qiniu')
+const Mustache = require('mustache')
 
 const paths = require('./utils/paths')
 const logger = require('./utils/logger')
@@ -107,12 +108,28 @@ async function uploadFile(localFile, bucket, key, mac) {
   return runWithRetry(putFile, 3)
 }
 
+function getDeployConfig(deploy) {
+  const { config } = deploy
+  const model = {
+    process: {
+      env: process.env
+    }
+  }
+
+  return Object.keys(config).reduce((prev, curr) => {
+    prev[curr] = Mustache.render(config[curr], model)
+    return prev
+  }, {})
+}
+
 async function upload() {
   const buildConfig = await findBuildConfig()
-  const deployConfig = buildConfig.deploy.config
+  const { deploy, publicUrl } = buildConfig
   const distPath = paths.getDistPath(buildConfig)
-  const prefix = getPathFromUrl(buildConfig.publicUrl, false)
-  const mac = new qiniu.auth.digest.Mac(deployConfig.accessKey, deployConfig.secretKey)
+  const prefix = getPathFromUrl(publicUrl, false)
+  const { accessKey, secretKey, bucket } = getDeployConfig(deploy)
+
+  const mac = new qiniu.auth.digest.Mac(accessKey, secretKey)
   const files = await getAllFiles(distPath)
 
   const concurrentLimit = 50
@@ -125,7 +142,7 @@ async function upload() {
       return logger.info(`[IGNORE] ${filePath}`)
     }
 
-    await uploadFile(filePath, deployConfig.bucket, key, mac)
+    await uploadFile(filePath, bucket, key, mac)
     logger.info(`[UPLOAD] ${filePath} -> ${key}`)
   }, concurrentLimit)
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-builder",
-  "version": "1.18.0-beta.3",
+  "version": "1.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10274,6 +10274,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
     },
     "nan": {
       "version": "2.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-builder",
-  "version": "1.18.0-beta.3",
+  "version": "1.18.0",
   "bin": {
     "fec-builder": "./bin/fec-builder"
   },
@@ -40,6 +40,7 @@
     "lodash": "^4.17.15",
     "log4js": "^4.1.0",
     "mini-css-extract-plugin": "^0.5.0",
+    "mustache": "^4.2.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "postcss-loader": "^2.0.8",
     "qiniu": "^7.2.1",

--- a/preset-configs/config.schema.json
+++ b/preset-configs/config.schema.json
@@ -150,7 +150,7 @@
         "target": { "type": "string", "enum": ["qiniu"], "description": "部署目标" },
         "config": {
           "type": "object",
-          "description": "针对当前部署目标的配置信息，如 target 为 `\"qiniu\"` 时，需要提供的 config 形如：\n```json\n{\n  \"AccessKey\": \"xxx\",\n  \"SecretKey\": \"yyy\",\n  \"bucket\": \"zzz\"\n}\n```\n表示使用 `xxx`、`yyy` 分别作为 AccessKey 与 SecretKey，上传到名为 `zzz` 的 bucket。"
+          "description": "针对当前部署目标的配置信息，如 target 为 `\"qiniu\"` 时，需要提供的 config 形如：\n```json\n{\n \"accessKey\": \"xxx\",\n \"secretKey\": \"yyy\",\n \"bucket\": \"zzz\"\n}\n```\n表示使用 `xxx`、`yyy` 分别作为 accessKey 与 secretKey，上传到名为 `zzz` 的 bucket。\n也可以通过环境变量的形式来配置，例如：\n```json\n{\n \"accessKey\": \"{{process.env.BUILD_DEPLOY_ACCESS_KEY}}\",\n \"secretKey\": \"{{process.env.BUILD_DEPLOY_SECRET_KEY}}\",\n \"bucket\": \"zzz\"\n}\n```\n表示使用环境变量 `BUILD_DEPLOY_ACCESS_KEY`、`BUILD_DEPLOY_SECRET_KEY` 的值分别作为 accessKey 与 secretKey，上传到名为 `zzz` 的 bucket。"
         }
       }
     },

--- a/preset-configs/default.json
+++ b/preset-configs/default.json
@@ -54,8 +54,8 @@
   "deploy": {
     "target": "qiniu",
     "config": {
-      "AccessKey": "",
-      "SecretKey": "",
+      "accessKey": "",
+      "secretKey": "",
       "bucket": ""
     }
   },


### PR DESCRIPTION
clone from: https://github.com/qiniu/builder/pull/174

build-config.json 中的 deploy.config 支持以环境变量的形式设置，例如：

```json
{
  "accessKey": "{{process.env.BUILD_DEPLOY_ACCESS_KEY}}",
  "secretKey": "{{process.env.BUILD_DEPLOY_SECRET_KEY}}",
  "bucket": "bucket-sample"
}
```

表示使用环境变量 `BUILD_DEPLOY_ACCESS_KEY`、`BUILD_DEPLOY_SECRET_KEY` 的值分别作为 accessKey 与 secretKey，上传到名为 `bucket-sample` 的 bucket。

